### PR TITLE
fix: Don't reencrypt vault with no private values using Model.build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.circleci
+.github
+.prettierrc.json
+.gitleaksignore
+catalog-info.yaml
+test/

--- a/index.js
+++ b/index.js
@@ -66,6 +66,11 @@ EncryptedField.prototype.vault = function (name) {
       }
     },
     set: function (value) {
+      // If we're given an empty value, and nothing was previously stored in the vault,
+      // then we can skip this `set` call.
+      if (value && Object.keys(value).length === 0 && !this.getDataValue(name))
+        return;
+
       // if new data is set, we will use a new IV
       const new_iv = crypto.randomBytes(self._iv_length);
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@snyk/sequelize-encrypted",
   "description": "encrypted sequelize fields",
   "main": "index.js",
+  "version": "0.5.1",
   "scripts": {
     "format": "prettier --write '*.j?' 'test/*.j?'",
     "lint": "prettier   --check '*.j?' 'test/*.j?'",

--- a/test/index.js
+++ b/test/index.js
@@ -33,6 +33,25 @@ describe('sequelize-encrypted', () => {
     await user.save();
     const found = await User.findByPk(user.id);
     assert.equal(found.private_1, user.private_1);
+    assert.equal(found.changed(), false);
+  });
+
+  it('should not reencrypt/change when building from a serialized ORM object with no encrypted values', async () => {
+    const user = User.build();
+    user.name = 'Test User';
+
+    await user.save();
+    const plainUser = JSON.stringify(user.get({ plain: true }));
+
+    const rehydratedUser = User.build(JSON.parse(plainUser), {
+      isNewRecord: false,
+    });
+
+    assert.equal(rehydratedUser.changed().includes('encrypted'), false);
+    assert.equal(rehydratedUser.changed().includes('another_encrypted'), false);
+
+    // User can still be saved...
+    await rehydratedUser.save();
   });
 
   it('should support multiple encrypted fields', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -139,4 +139,35 @@ describe('sequelize-encrypted', () => {
     assert.equal(foundFromKeyOne.private, modelUsingKeyOne.private);
     assert.equal(foundFromKeyTwo.private, modelUsingKeyTwo.private);
   });
+
+  it('should support reencryption properly', async () => {
+    const user = User.build();
+    user.private_1 = 'baz';
+    user.private_2 = 'foobar';
+    await user.save();
+
+    const foundUser = await User.findByPk(user.id);
+    
+    // Assert initial encryption works as expected
+    assert.equal(foundUser.private_1, user.private_1);
+    assert.equal(foundUser.private_2, user.private_2);
+    assert.equal(JSON.stringify(foundUser.encrypted), JSON.stringify(user.encrypted));
+    assert.equal(JSON.stringify(foundUser.another_encrypted), JSON.stringify(user.another_encrypted));
+
+    // Reencrypt by setting to self
+    foundUser.encrypted = foundUser.encrypted;
+    foundUser.another_encrypted = foundUser.another_encrypted;
+    await foundUser.save();
+
+    const foundUser2 = await User.findByPk(user.id);
+
+    assert.equal(foundUser2.private_1, user.private_1);
+    assert.equal(foundUser2.private_2, user.private_2);
+    assert.equal(JSON.stringify(foundUser2.encrypted), JSON.stringify(user.encrypted));
+    assert.equal(JSON.stringify(foundUser2.another_encrypted), JSON.stringify(user.another_encrypted));
+
+    // Backing data should change as part of reencryption
+    assert.notEqual(foundUser2['dataValues']['encrypted'], user['dataValues']['encrypted']);
+    assert.notEqual(foundUser2['dataValues']['another_encrypted'], user['dataValues']['another_encrypted']);
+  })
 });

--- a/test/index.js
+++ b/test/index.js
@@ -147,12 +147,18 @@ describe('sequelize-encrypted', () => {
     await user.save();
 
     const foundUser = await User.findByPk(user.id);
-    
+
     // Assert initial encryption works as expected
     assert.equal(foundUser.private_1, user.private_1);
     assert.equal(foundUser.private_2, user.private_2);
-    assert.equal(JSON.stringify(foundUser.encrypted), JSON.stringify(user.encrypted));
-    assert.equal(JSON.stringify(foundUser.another_encrypted), JSON.stringify(user.another_encrypted));
+    assert.equal(
+      JSON.stringify(foundUser.encrypted),
+      JSON.stringify(user.encrypted),
+    );
+    assert.equal(
+      JSON.stringify(foundUser.another_encrypted),
+      JSON.stringify(user.another_encrypted),
+    );
 
     // Reencrypt by setting to self
     foundUser.encrypted = foundUser.encrypted;
@@ -163,11 +169,23 @@ describe('sequelize-encrypted', () => {
 
     assert.equal(foundUser2.private_1, user.private_1);
     assert.equal(foundUser2.private_2, user.private_2);
-    assert.equal(JSON.stringify(foundUser2.encrypted), JSON.stringify(user.encrypted));
-    assert.equal(JSON.stringify(foundUser2.another_encrypted), JSON.stringify(user.another_encrypted));
+    assert.equal(
+      JSON.stringify(foundUser2.encrypted),
+      JSON.stringify(user.encrypted),
+    );
+    assert.equal(
+      JSON.stringify(foundUser2.another_encrypted),
+      JSON.stringify(user.another_encrypted),
+    );
 
     // Backing data should change as part of reencryption
-    assert.notEqual(foundUser2['dataValues']['encrypted'], user['dataValues']['encrypted']);
-    assert.notEqual(foundUser2['dataValues']['another_encrypted'], user['dataValues']['another_encrypted']);
-  })
+    assert.notEqual(
+      foundUser2['dataValues']['encrypted'],
+      user['dataValues']['encrypted'],
+    );
+    assert.notEqual(
+      foundUser2['dataValues']['another_encrypted'],
+      user['dataValues']['another_encrypted'],
+    );
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -188,4 +188,37 @@ describe('sequelize-encrypted', () => {
       user['dataValues']['another_encrypted'],
     );
   });
+
+  it('should treat providing an empty encrypted vault the same as an empty object', async () => {
+    const user = User.build();
+    await user.save();
+
+
+    const user2 = User.build();
+    user2.encrypted = {};
+
+    const found = await User.findByPk(user.id);
+    
+    assert.equal(user['dataValues']['encrypted'], undefined);
+    assert.equal(user2['dataValues']['encrypted'], undefined);
+    assert.equal(found['dataValues']['encrypted'], undefined);
+  });
+
+  it('should support clearing an existing vault using an empty object set', async () => {
+    const user = User.build();
+    user.private_1 = 'abc';
+    await user.save();
+
+
+    const found = await User.findByPk(user.id);
+
+    assert.notEqual(found['dataValues']['encrypted'], undefined);
+
+    // Clear the encrypted vault
+    found.encrypted = {};
+    await found.save();
+
+    const found2 = await User.findByPk(user.id);
+    assert.equal(JSON.stringify(found2.encrypted), "{}")
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -193,12 +193,11 @@ describe('sequelize-encrypted', () => {
     const user = User.build();
     await user.save();
 
-
     const user2 = User.build();
     user2.encrypted = {};
 
     const found = await User.findByPk(user.id);
-    
+
     assert.equal(user['dataValues']['encrypted'], undefined);
     assert.equal(user2['dataValues']['encrypted'], undefined);
     assert.equal(found['dataValues']['encrypted'], undefined);
@@ -209,7 +208,6 @@ describe('sequelize-encrypted', () => {
     user.private_1 = 'abc';
     await user.save();
 
-
     const found = await User.findByPk(user.id);
 
     assert.notEqual(found['dataValues']['encrypted'], undefined);
@@ -219,6 +217,6 @@ describe('sequelize-encrypted', () => {
     await found.save();
 
     const found2 = await User.findByPk(user.id);
-    assert.equal(JSON.stringify(found2.encrypted), "{}")
+    assert.equal(JSON.stringify(found2.encrypted), '{}');
   });
 });


### PR DESCRIPTION
We sometimes serialize a Sequelize model, and then rehydrate it using `Model.build` at a later time. This object is in the form:

```tsx
{
// ... Some attributes ...
SubObject: [
	{
		// ... Some attributes ...
		encrypted: {}
	},
	// And many many more...
]
}
```

Where the `encrypted` field is a `sequelize-encrypted` vault. 

As part of `Model.build`, Sequelize calls all custom field setters. This results in `Vault.set()` being called with `{}`, at which point it is re-encrypted in case the user ends up calling `.save()`. However, given the default value for a Vault call is `{}` anyway, this operation is pointless.

With many sub-objects, this behaviour becomes pathological and causes serious performance issues:
![image](https://github.com/user-attachments/assets/fcc4719e-bfa9-411b-8d22-ede5c28de2be)

This PR simply skips the re-encryption operation if `Vault.set()` is called with an empty object (and there's no existing data to override).

**Note**, that this PR only helps performance in cases where the vault is empty - in cases where it is not, the existing behaviour is maintained. Ideally, (re)encryption would be deferred to the point that the user actually calls `.save()` on a field.

With the same data, after this PR a performance trace is much saner (44ms -> 17ms on 1500 subobjects):
![image](https://github.com/user-attachments/assets/0dbd0c31-8a6a-4edb-a83f-86f93590db08)
