### PR TITLE
chore(codeowners): add @snyk/product-unification_data-platform-registry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/platformeng_jedi
+* @snyk/platformeng_jedi @snyk/product-unification_data-platform-registry


### PR DESCRIPTION
Adds `@snyk/product-unification_data-platform-registry` as a co-owner on **every**
CODEOWNERS line that already lists `@snyk/platformeng_jedi`, so the two teams own
the same paths.

Mechanical change, generated by script:

- The new team handle is inserted immediately after `@snyk/platformeng_jedi` on each
  matching line. No lines added, removed, or reordered.
- Lines that do not mention `@snyk/platformeng_jedi` are byte-identical.
- Other owners on the same line (individuals or other teams) are untouched.
- Re-running the generator is a no-op, so this is safe to regenerate.

> [!IMPORTANT]
> For GitHub to treat the new entry as valid, `@snyk/product-unification_data-platform-registry`
> needs at least **write** access to this repository. Without it GitHub flags the
> CODEOWNERS entry as an error and ignores it for review assignment. Please confirm
> the team grant is in place before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
